### PR TITLE
Support table name==col name

### DIFF
--- a/pymysql/cursors.py
+++ b/pymysql/cursors.py
@@ -379,7 +379,7 @@ class DictCursorMixin(object):
         if self.description:
             for f in self._result.fields:
                 name = f.name
-                if name in fields:
+                if name in fields or name == f.table_name:
                     name = f.table_name + '.' + name
                 fields.append(name)
             self._fields = fields


### PR DESCRIPTION
Before, a JOIN'd column named the same as its table (e.g. `question.question`) would be stored in `fields` as simply `question`, making it seem as though it belongs to the 'main' table in the query.

This support is particularly important when turning a row dict into a set of nested dicts, the children being JOIN'd rows.